### PR TITLE
[Chore] Bump `@journeyapps/powersync-attachments` package

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,14 +17,14 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.powersync-example"
+      "bundleIdentifier": "co.powersync.example"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.anonymous.powersyncexample"
+      "package": "co.powersync.example"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/library/powersync/PhotoAttachmentQueue.ts
+++ b/library/powersync/PhotoAttachmentQueue.ts
@@ -1,7 +1,12 @@
 import * as FileSystem from 'expo-file-system';
 import { v4 as uuid } from 'uuid';
 import { AppConfig } from '../supabase/AppConfig';
-import { AbstractAttachmentQueue, AttachmentRecord, AttachmentState } from '@journeyapps/powersync-attachments';
+import {
+  AbstractAttachmentQueue,
+  AttachmentRecord,
+  AttachmentState,
+  EncodingType
+} from '@journeyapps/powersync-attachments';
 import { TODO_TABLE } from './AppSchema';
 
 export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
@@ -39,10 +44,11 @@ export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
 
   async savePhoto(base64Data: string): Promise<AttachmentRecord> {
     const photoAttachment = await this.newAttachmentRecord();
-    photoAttachment.local_uri = this.getLocalUri(photoAttachment.filename);
-    await this.storage.writeFile(photoAttachment.local_uri!, base64Data, { encoding: FileSystem.EncodingType.Base64 });
+    photoAttachment.local_uri = this.getLocalFilePathSuffix(photoAttachment.filename);
+    const localUri = this.getLocalUri(photoAttachment.local_uri);
+    await this.storage.writeFile(localUri, base64Data, { encoding: FileSystem.EncodingType.Base64 });
 
-    const fileInfo = await FileSystem.getInfoAsync(photoAttachment.local_uri!);
+    const fileInfo = await FileSystem.getInfoAsync(localUri);
     if (fileInfo.exists) {
       photoAttachment.size = fileInfo.size;
     }

--- a/library/widgets/TodoItemWidget.tsx
+++ b/library/widgets/TodoItemWidget.tsx
@@ -2,6 +2,7 @@ import { CameraCapturedPicture } from 'expo-camera';
 import React from 'react';
 import { ActivityIndicator, Alert, View, Modal, StyleSheet } from 'react-native';
 import { ListItem, Button, Icon, Image } from 'react-native-elements';
+import { useSystem } from '../powersync/system';
 import { CameraWidget } from './CameraWidget';
 import { TodoRecord } from '../powersync/AppSchema';
 import { AttachmentRecord } from '@journeyapps/powersync-attachments';
@@ -18,6 +19,7 @@ export const TodoItemWidget: React.FC<TodoItemWidgetProps> = (props) => {
   const { record, photoAttachment, onDelete, onToggleCompletion, onSavePhoto } = props;
   const [loading, setLoading] = React.useState(false);
   const [isCameraVisible, setCameraVisible] = React.useState(false);
+  const { attachmentQueue } = useSystem();
 
   const handleCancel = React.useCallback(() => {
     setCameraVisible(false);
@@ -71,7 +73,7 @@ export const TodoItemWidget: React.FC<TodoItemWidgetProps> = (props) => {
           <Icon name={'camera'} type="font-awesome" onPress={() => setCameraVisible(true)} />
         ) : photoAttachment?.local_uri != null ? (
           <Image
-            source={{ uri: photoAttachment.local_uri }}
+            source={{ uri: `${attachmentQueue.getLocalUri(photoAttachment.local_uri)}` }}
             containerStyle={styles.item}
             PlaceholderContent={<ActivityIndicator />}
           />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powersync-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "expo-router/entry",
   "scripts": {
     "android": "expo run:android",
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/vector-icons": "^13.0.0",
-    "@journeyapps/powersync-attachments": "0.0.5",
+    "@journeyapps/powersync-attachments": "^1.0.1",
     "@journeyapps/powersync-sdk-react-native": "^1.0.0",
     "@journeyapps/react-native-quick-sqlite": "^1.0.0",
     "@react-native-community/masked-view": "^0.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,10 +1197,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/cli@0.10.12":
-  version "0.10.12"
-  resolved "https://registry.npmjs.org/@expo/cli/-/cli-0.10.12.tgz#7a5f8d1a19912496fd6c848096321f8d60b5fa8c"
-  integrity sha512-sc4IkRBbm6HO1Z/0JeJMY/sJiyCAfHyt2EOHhAY8jYfbXr/aqCIGsPrwEGQAfGpsE2OPvyzRa+byZG03HRPTkQ==
+"@expo/cli@0.10.16":
+  version "0.10.16"
+  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-0.10.16.tgz#42f9aaf08884f70f3a671b7d6b4f138ad39192d7"
+  integrity sha512-EwgnRN5AMElg0JJjFLJTPk5hYkVXxnNMLIvZBiTfGoCq+rDw6u7Mg5l2Bbm/geSHOoplaHyPZ/Wr23FAuZWehA==
   dependencies:
     "@babel/runtime" "^7.20.0"
     "@expo/code-signing-certificates" "0.0.5"
@@ -1608,12 +1608,12 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@journeyapps/powersync-attachments@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-attachments/-/powersync-attachments-0.0.5.tgz#7b13a246d47afaa5ef2101f1434d6c76c79104c5"
-  integrity sha512-g7Oum0n3y3Tw6OXCFHzCdyD8isRGWd+dxx1oLR1dONd0xhRC8M6VztAZPBiGQQ2MvCYKbbL8Oe/eymoryelBTA==
+"@journeyapps/powersync-attachments@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@journeyapps/powersync-attachments/-/powersync-attachments-1.0.1.tgz#9237590cf13269105b98a2b45305b0e3f8ddffde"
+  integrity sha512-Da605lyrW+iNM27kxBXtz4+aw/vIOKnA089w82wzdJFpK8Uov37gKq0w+/2qQ1p2axXRiQKAQ+dqeyne67fBpw==
   dependencies:
-    "@journeyapps/powersync-sdk-common" "0.1.4"
+    "@journeyapps/powersync-sdk-common" "1.0.0"
 
 "@journeyapps/powersync-react@1.0.0":
   version "1.0.0"
@@ -1621,19 +1621,6 @@
   integrity sha512-WMSIScA4cZbBBFAD9p/v6vn/0ixv0tLaVMcx84pIkUSy9FNn8gI0G9ciwUIcyGSNI1sMnCjyH76NwXo48WtY5w==
   dependencies:
     "@journeyapps/powersync-sdk-common" "1.0.0"
-
-"@journeyapps/powersync-sdk-common@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/@journeyapps/powersync-sdk-common/-/powersync-sdk-common-0.1.4.tgz#6da7503c0645d8a4eaa9fd962c44cb92206d1cef"
-  integrity sha512-VFf/ej7sy1NxL0yFkMwPIIjCI9TJ6EWj0thx5WPEanhLeCqgA5OdTmSmp39Tc6EYxF1VZdLWqUMvhT+r0WMFuQ==
-  dependencies:
-    async-mutex "^0.4.0"
-    can-ndjson-stream "^1.0.2"
-    event-iterator "^2.0.0"
-    js-logger "^1.6.1"
-    lodash "^4.17.21"
-    object-hash "^3.0.0"
-    uuid "^3.0.0"
 
 "@journeyapps/powersync-sdk-common@1.0.0":
   version "1.0.0"
@@ -3553,10 +3540,17 @@ expo-file-system@^15.6.0:
   dependencies:
     uuid "^3.4.0"
 
-expo-file-system@~15.4.0, expo-file-system@~15.4.4:
+expo-file-system@~15.4.0:
   version "15.4.4"
   resolved "https://registry.npmjs.org/expo-file-system/-/expo-file-system-15.4.4.tgz#b29e0507b57ee0cc7173cf8844aaf992e411f518"
   integrity sha512-F0xS88D85F7qVQ61r0qBnzh6VW/s6iIl+VaQEEi2nAIOQHw1JIEj4yCXPLTtbyn5VmArbe2dSL3KYz1V+BLkKA==
+  dependencies:
+    uuid "^3.4.0"
+
+expo-file-system@~15.4.5:
+  version "15.4.5"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-15.4.5.tgz#3ef68583027ff0e2fb9eca7a22b3caff6cfc550d"
+  integrity sha512-xy61KaTaDgXhT/dllwYDHm3ch026EyO8j4eC6wSVr/yE12MMMxAC09yGwy4f7kkOs6ztGVQF5j7ldRzNLN4l0Q==
   dependencies:
     uuid "^3.4.0"
 
@@ -3602,10 +3596,10 @@ expo-modules-autolinking@1.5.1, expo-modules-autolinking@^1.5.1:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.5.11.tgz#6ee33641cec5ef9c629393a267cef122110d2bf0"
-  integrity sha512-1Dj2t74nVjxq6xEQf2b9WFfAMhPzVnR0thY0PfRFgob4STyj3sq1U4PIHVWvKQBtDKIa227DrNRb+Hu+LqKWQg==
+expo-modules-core@1.5.12:
+  version "1.5.12"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.5.12.tgz#07eb4de4bf25a3ec3e1924403e73d13c656613fd"
+  integrity sha512-mY4wTDU458dhwk7IVxLNkePlYXjs9BTgk4NQHBUXf0LapXsvr+i711qPZaFNO4egf5qq6fQV+Yfd/KUguHstnQ==
   dependencies:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
@@ -3641,12 +3635,12 @@ expo-status-bar@~1.6.0:
   integrity sha512-e//Oi2WPdomMlMDD3skE4+1ZarKCJ/suvcB4Jo/nO427niKug5oppcPNYO+csR6y3ZglGuypS+3pp/hJ+Xp6fQ==
 
 expo@~49.0.8:
-  version "49.0.11"
-  resolved "https://registry.npmjs.org/expo/-/expo-49.0.11.tgz#2ad565aaf0e4533c17e5dcbe0e0020da856cbca9"
-  integrity sha512-4UtSnaVn4bAEsdp2Z2I8okCJEmAm2cj1Rl3ifm79fI4zMz3EqBaXMKs6OdMSTa6DWq3dZp8C/5dEKy/ynah0CA==
+  version "49.0.21"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-49.0.21.tgz#32a66b32d0a233879ec3afdec35fb63d2cc8a4c3"
+  integrity sha512-JpHL6V0yt8/fzsmkAdPdtsah+lU6Si4ac7MDklLYvzEil7HAFEsN/pf06wQ21ax4C+BL27hI6JJoD34tzXUCJA==
   dependencies:
     "@babel/runtime" "^7.20.0"
-    "@expo/cli" "0.10.12"
+    "@expo/cli" "0.10.16"
     "@expo/config" "8.1.2"
     "@expo/config-plugins" "7.2.5"
     "@expo/vector-icons" "^13.0.0"
@@ -3654,11 +3648,11 @@ expo@~49.0.8:
     expo-application "~5.3.0"
     expo-asset "~8.10.1"
     expo-constants "~14.4.2"
-    expo-file-system "~15.4.4"
+    expo-file-system "~15.4.5"
     expo-font "~11.4.0"
     expo-keep-awake "~12.3.0"
     expo-modules-autolinking "1.5.1"
-    expo-modules-core "1.5.11"
+    expo-modules-core "1.5.12"
     fbemitter "^3.0.0"
     invariant "^2.2.4"
     md5-file "^3.2.3"


### PR DESCRIPTION
## Description

Related: https://github.com/powersync-ja/powersync-react-native-sdk/pull/37

### Work done

- Bump `@journeyapps/powersync-attachments` package version that fixes `localUri` issue when testing on iOS simulator. 
- Updates to demo app to use `getLocalFilePathSuffix()` in combination with `getLocalUri()`
- Chore: update `app.json` config to use `co.powersync.example` bundle ID and package